### PR TITLE
Fix typo in 'mkdocs.yml'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,6 @@ pages:
 - ['index.md', 'Django Google Dork']
 - ['introduction.md', 'Introduction']
 - ['usage.md', 'Usage']
-- ['development.md', 'For developpers']
+- ['development.md', 'For developers']
 
 theme: readthedocs


### PR DESCRIPTION
Couldn't help myself :stuck_out_tongue: 
